### PR TITLE
Fix the DataCollector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.2.1
+-----
+
+* Fix a crash in `MercureDataCollector`
+
 0.2.0
 -----
 

--- a/src/DataCollector/MercureDataCollector.php
+++ b/src/DataCollector/MercureDataCollector.php
@@ -36,7 +36,7 @@ final class MercureDataCollector extends DataCollector
             'count' => 0,
             'duration' => 0.0,
             'memory' => 0,
-            'publishers' => $this->publishers,
+            'publishers' => iterator_to_array($this->publishers),
         ];
 
         foreach ($this->publishers as $name => $publisher) {


### PR DESCRIPTION
The `ArgumentIterator` cannot be serialized, and so cannot be stored by the data collector. This PR prevents a crash.