### PR TITLE
Reduce possibility of breaking the symfony Toolbar

### DIFF
--- a/src/DataCollector/MercureDataCollector.php
+++ b/src/DataCollector/MercureDataCollector.php
@@ -36,8 +36,12 @@ final class MercureDataCollector extends DataCollector
             'count' => 0,
             'duration' => 0.0,
             'memory' => 0,
-            'publishers' => iterator_to_array($this->publishers),
+            'publishers' => [],
         ];
+
+        foreach ($this->publishers as $name => $publisher) {
+            $this->data['publishers'][$name]['messages'] = $publisher->getMessages();
+        }
 
         foreach ($this->publishers as $name => $publisher) {
             $this->data['duration'] += $publisher->getDuration();


### PR DESCRIPTION
By only dumping the needed relevant information needed for the toolbar/debug page, we avoid dumping data which could break the symfony toolbar (FileProfilerStorage), which cannot serialize Closures. This can happen if the publisher uses a factory
In this case the UsageTrackingTokenStorage of the symfony authentication component uses the ContainerInterface/SessionLocator, which creates a Closure
Fixes https://github.com/symfony/mercure-bundle/issues/19