### PR TITLE
Add mercure.publisher tag to publisher services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.2.7
+-----
+
+* Add `mercure.publisher` tag on publisher services
+
 0.2.6
 -----
 

--- a/src/DependencyInjection/MercureExtension.php
+++ b/src/DependencyInjection/MercureExtension.php
@@ -74,7 +74,10 @@ final class MercureExtension extends Extension
 
             $bus = $hub['bus'] ?? null;
             $attributes = null === $bus ? [] : ['bus' => $hub['bus']];
-            $publisherDefinition->addTag('messenger.message_handler', $attributes);
+
+            $publisherDefinition
+                ->addTag('messenger.message_handler', $attributes)
+                ->addTag('mercure.publisher');
 
             if ($enableProfiler) {
                 $container->register("$hubId.traceable", TraceablePublisher::class)

--- a/tests/DependencyInjection/MercureExtensionTest.php
+++ b/tests/DependencyInjection/MercureExtensionTest.php
@@ -42,6 +42,7 @@ class MercureExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('mercure.hub.default.jwt_provider'));
         $this->assertTrue($container->hasDefinition('mercure.hub.default.publisher'));
         $this->assertSame('https://demo.mercure.rocks/hub', $container->getDefinition('mercure.hub.default.publisher')->getArgument(0));
+        $this->assertArrayHasKey('mercure.publisher', $container->getDefinition('mercure.hub.default.publisher')->getTags());
         $this->assertSame('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.HB0k08BaV8KlLZ3EafCRlTDGbkd9qdznCzJQ_l8ELTU', $container->getDefinition('mercure.hub.default.jwt_provider')->getArgument(0));
         $this->assertSame(['default' => 'https://demo.mercure.rocks/hub'], $container->getParameter('mercure.hubs'));
         $this->assertSame('https://demo.mercure.rocks/hub', $container->getParameter('mercure.default_hub'));


### PR DESCRIPTION
In order to implement https://github.com/symfony/symfony/pull/39342, we need to discover every publisher available in the service container. 

Therefore, this PR simply add a `mercure.publisher` tag on each publisher service.