### PR TITLE
Add dependency to lcobucci/jwt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: php
 jobs:
   include:
     - php: '7.2'
+      env: lcobucci=0
     - php: '7.3'
+      env: lcobucci=0
     - php: '7.4'
     - php: '8.0'
       env: lint=1
@@ -15,7 +17,7 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-  - if [[ $lint = '1' ]]; then composer require --no-update --dev lcobucci/jwt:^4.0; fi
+  - if [[ $lcobucci = '0' ]]; then composer remove --no-update lcobucci/jwt; fi
   - if [[ $lint = '1' ]]; then wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.18.4/php-cs-fixer.phar; fi
   - if [[ $lint = '1' ]]; then wget https://github.com/phpstan/phpstan/releases/download/0.12.82/phpstan.phar; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: php
 jobs:
   include:
     - php: '7.2'
-      env: lcobucci=0
     - php: '7.3'
-      env: lcobucci=0
     - php: '7.4'
     - php: '8.0'
       env: lint=1
@@ -17,7 +15,6 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-  - if [[ $lcobucci = '0' ]]; then composer remove --no-update lcobucci/jwt; fi
   - if [[ $lint = '1' ]]; then wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.18.4/php-cs-fixer.phar; fi
   - if [[ $lint = '1' ]]; then wget https://github.com/phpstan/phpstan/releases/download/0.12.82/phpstan.phar; fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 CHANGELOG
 =========
 
+0.3.2
+-----
+
+* Full compatibility with PHP 7.1
+* Enable JWT support by default
+
 0.3.1
 -----
 
-* Add a configuration option to set a defaut expiration for the JWT and the cookie when using the `Authorization` class
+* Add a configuration option to set a default expiration for the JWT and the cookie when using the `Authorization` class
 
 0.3.0
 -----

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "lcobucci/jwt": "^4.0",
+        "lcobucci/jwt": "^3.4|^4.0",
         "symfony/config": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
         "symfony/http-kernel": "^4.4|^5.0",
-        "symfony/mercure": "^0.5",
+        "symfony/mercure": "^0.5.3",
         "symfony/web-link": "^4.4|^5.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
+        "lcobucci/jwt": "^4.0",
         "symfony/config": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
         "symfony/http-kernel": "^4.4|^5.0",


### PR DESCRIPTION
Currently, installing the recipe throws an error because `lcobucci/jwt` is missing, while required but the recipe.

An alternative to adding `lcobucci/jwt` as a dependency could to create a pack for Mercure and another one for Symfony UX Turbo, but this looks overkill.

Note that `lcobucci/jwt` 4 (the only version supported by the Mercure component) requires PHP 7.4+. This is still possible to use this bundle with older PHP versions and without `lcobucci/jwt` by adding `"lcobucci/jwt": "*"` to the `replace` section of the `composer.json` in your project.