### PR TITLE
fix: compatibility with Symfony 4

### DIFF
--- a/src/DependencyInjection/MercureExtension.php
+++ b/src/DependencyInjection/MercureExtension.php
@@ -267,7 +267,7 @@ final class MercureExtension extends Extension
                 ->addTag('kernel.event_subscriber', ['priority' => -10]);
         }
 
-        if (class_exists(TwigMercureExtension::class) && class_exists(Environment::class)) {
+        if (class_exists(Environment::class) && class_exists(TwigMercureExtension::class)) {
             $container->register(TwigMercureExtension::class)
                 ->setArguments([new Reference(HubRegistry::class), new Reference(Authorization::class), new Reference('request_stack')])
                 ->addTag('twig.extension');


### PR DESCRIPTION
To prevent an autoloading error with Symfony 4, we must check if Twig is installed before checking for Mercure Component 0.6.

Fixes https://github.com/symfony/recipes/pull/1007/checks?check_run_id=3871855256.