### PR TITLE
Early return when Authorization does not exist

### DIFF
--- a/src/MercureBundle.php
+++ b/src/MercureBundle.php
@@ -31,6 +31,10 @@ final class MercureBundle extends Bundle
         $container->addCompilerPass(new class() implements CompilerPassInterface {
             public function process(ContainerBuilder $container): void
             {
+                if (!$container->hasDefinition(Authorization::class)) {
+                    return;
+                }
+
                 $definition = $container->getDefinition(Authorization::class);
                 if (
                     null === $definition->getArgument(1) &&


### PR DESCRIPTION
When you enable the bundle without setting any configuration, you get an error:
```
  [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]
  You have requested a non-existent service "Symfony\Component\Mercure\Authorization".
```
This is because the Extension only registers this when you have one or more hubs configured.