### PR TITLE
fix: use the right argument index for `Authorization` cookie lifetime

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.1.3",
         "lcobucci/jwt": "^3.4|^4.0",
         "symfony/config": "^4.4|^5.0|^6.0",
-        "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+        "symfony/dependency-injection": "^4.4|^5.4|^6.0",
         "symfony/http-kernel": "^4.4|^5.0|^6.0",
         "symfony/mercure": "^0.5.3|^0.6",
         "symfony/web-link": "^4.4|^5.0|^6.0"

--- a/src/MercureBundle.php
+++ b/src/MercureBundle.php
@@ -31,13 +31,17 @@ final class MercureBundle extends Bundle
         $container->addCompilerPass(new class() implements CompilerPassInterface {
             public function process(ContainerBuilder $container): void
             {
+                if (!$container->hasDefinition(Authorization::class)) {
+                    return;
+                }
+
                 $definition = $container->getDefinition(Authorization::class);
                 if (
                     null === $definition->getArgument(1) &&
                     $container->hasParameter('session.storage.options')
                 ) {
                     $definition->setArgument(
-                        2,
+                        1,
                         $container->getParameter('session.storage.options')['cookie_lifetime'] ?? null
                     );
                 }

--- a/tests/MercureBundleTest.php
+++ b/tests/MercureBundleTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Bundle\MercureBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MercureBundle\DependencyInjection\MercureExtension;
+use Symfony\Bundle\MercureBundle\MercureBundle;
+use Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\InlineServiceDefinitionsPass;
+use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\Mercure\Authorization;
+
+class MercureBundleTest extends TestCase
+{
+    public function testBuildSetsAuthorizationCookieLifetime(): void
+    {
+        $config = [
+            'mercure' => [
+                'hubs' => [
+                    'default' => [
+                        'url' => 'https://demo.mercure.rocks/hub',
+                        'jwt' => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.HB0k08BaV8KlLZ3EafCRlTDGbkd9qdznCzJQ_l8ELTU',
+                    ],
+                ],
+            ],
+        ];
+
+        $container = new ContainerBuilder(new ParameterBag([
+            'kernel.debug' => false,
+            'session.storage.options' => ['cookie_lifetime' => 60],
+        ]));
+
+        (new MercureExtension())->load($config, $container);
+        (new MercureBundle())->build($container);
+
+        // prevent unused services removal/inlining and missing optional services errors
+        $container->getCompilerPassConfig()->setRemovingPasses(array_filter($container->getCompilerPassConfig()->getRemovingPasses(), function (CompilerPassInterface $pass) {
+            return !(
+                $pass instanceof RemoveUnusedDefinitionsPass ||
+                $pass instanceof CheckExceptionOnInvalidReferenceBehaviorPass ||
+                $pass instanceof InlineServiceDefinitionsPass
+            );
+        }));
+
+        $container->compile();
+
+        $this->assertSame(60, $container->getDefinition(Authorization::class)->getArgument(1));
+    }
+
+    public function testBuildSkipsSettingAuthorizationCookieLifetimeIfNotWired(): void
+    {
+        $config = ['mercure' => ['hubs' => []]];
+
+        $container = new ContainerBuilder(new ParameterBag([
+            'kernel.debug' => false,
+        ]));
+
+        (new MercureExtension())->load($config, $container);
+        (new MercureBundle())->build($container);
+
+        // prevent unused services removal/inlining and missing optional services errors
+        $container->getCompilerPassConfig()->setRemovingPasses(array_filter($container->getCompilerPassConfig()->getRemovingPasses(), function (CompilerPassInterface $pass) {
+            return !(
+                $pass instanceof RemoveUnusedDefinitionsPass ||
+                $pass instanceof CheckExceptionOnInvalidReferenceBehaviorPass ||
+                $pass instanceof InlineServiceDefinitionsPass
+            );
+        }));
+
+        $container->compile();
+
+        $this->assertFalse($container->hasDefinition(Authorization::class));
+    }
+}


### PR DESCRIPTION
Spotted in #68. Also embeds #68 (with test case)