### PR TITLE
Changing 0.4.0 to 0.3.7 for changelog as no break was made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-0.4.0
+0.3.7
 -----
 
 * Support for `symfony/ux-turbo` 2.9 using `symfony/stimulus-bundle`


### PR DESCRIPTION
Follow up of #80 - I was originally bumping the required `symfony/ux-turbo` version. But as that was removed, using 0.3.7 should be fine.