### PR TITLE
Adapt Icon to profiler redesign (minor)

### DIFF
--- a/src/Resources/views/Collector/mercure.html.twig
+++ b/src/Resources/views/Collector/mercure.html.twig
@@ -60,19 +60,21 @@
                                 <th>Retry</th>
                             </tr>
                             </thead>
-                            {% for i, message in data.messages %}
-                                <tr>
-                                    <td class="font-normal text-small text-muted nowrap">{{ i + 1 }}</td>
-                                    <td class="nowrap">{{ '%.0f'|format(message.duration) }} ms</td>
-                                    <td class="nowrap">{{ '%.2f'|format(message.memory / 1024 / 1024) }} MB</td>
-                                    <td class="font-normal text-small text-bold nowrap">{{ message.object.topics|join(',') }}</td>
-                                    <td>{{ dump(message.object.data) }}</td>
-                                    <td>{{ dump(message.object.private) }}</td>
-                                    <td class="nowrap">{{ message.object.id }}</td>
-                                    <td class="nowrap">{{ message.object.type }}</td>
-                                    <td class="nowrap">{{ message.object.retry }}</td>
-                                </tr>
-                            {% endfor %}
+                            <tbody>
+                                {% for message in data.messages %}
+                                    <tr>
+                                        <td class="font-normal text-small text-muted nowrap">{{ loop.index }}</td>
+                                        <td class="nowrap">{{ '%.0f'|format(message.duration) }} ms</td>
+                                        <td class="nowrap">{{ '%.2f'|format(message.memory / 1024 / 1024) }} MB</td>
+                                        <td class="font-normal text-small text-bold nowrap">{{ message.object.topics|join(',') }}</td>
+                                        <td>{{ dump(message.object.data) }}</td>
+                                        <td>{{ dump(message.object.private) }}</td>
+                                        <td class="nowrap">{{ message.object.id }}</td>
+                                        <td class="nowrap">{{ message.object.type }}</td>
+                                        <td class="nowrap">{{ message.object.retry }}</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
                         </table>
                     </div>
                 </div>

--- a/src/Resources/views/Collector/mercure.html.twig
+++ b/src/Resources/views/Collector/mercure.html.twig
@@ -26,7 +26,7 @@
     <h2>Messages</h2>
 
     {% if collector.count == 0 %}
-        <div class="empty">
+        <div class="empty empty-panel">
             <p>No messages have been collected.</p>
         </div>
     {% else %}

--- a/src/Resources/views/Icon/mercure.svg
+++ b/src/Resources/views/Icon/mercure.svg
@@ -1,22 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" id="Logo_Mercure" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
-	 y="0px" viewBox="0 0 147.5 144" style="enable-background:new 0 0 147.5 144;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:url(#SVGID_1_);}
-	.st1{fill:url(#SVGID_2_);}
-</style>
-<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="0" y1="352" x2="144" y2="352" gradientTransform="matrix(1 0 0 1 0 -280)">
-	<stop  offset="0" style="stop-color:#76C8DD"/>
-	<stop  offset="1" style="stop-color:#2AB3D7"/>
-</linearGradient>
-<path class="st0" d="M72,144c-39.7,0-72-32.3-72-72S32.3,0,72,0s72,32.3,72,72S111.7,144,72,144z M72,6.1C35.7,6.1,6.1,35.7,6.1,72
-	s29.6,65.9,65.9,65.9s66-29.6,66-65.9S108.4,6.1,72,6.1z"/>
-<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="15.5" y1="351.25" x2="128.5" y2="351.25" gradientTransform="matrix(1 0 0 1 0 -280)">
-	<stop  offset="0" style="stop-color:#76C8DD"/>
-	<stop  offset="1" style="stop-color:#2AB3D7"/>
-</linearGradient>
-<path class="st1" d="M72,14.7c-31.2,0-56.5,25.3-56.5,56.5c0,9.7,2.5,18.9,6.8,26.9c1.5-1.1,3.1-2.2,4.9-3.3
-	c31-18.5,58.4-33.7,76.6-62c0,0-1.3,32-19.7,46.9c-4.1,3.3-7.6,5.9-10.9,8c9.3-4.9,17.4-10.5,23.7-18c0,0-0.5,21.5-16.3,31
-	c-5.9,3.5-10.8,5.5-15.8,7c9-2,14.9-4.5,19.6-7.7c-4,13.3-12.7,20.3-26.2,22.3c-4.9,0.5-9.1-0.5-13.5-1.5c8.1,4.5,17.4,7,27.3,7
-	c31.2,0,56.5-25.3,56.5-56.5S103.3,14.7,72,14.7z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 147.5 144" fill="currentColor">
+	<path d="M72 144c-39.7 0-72-32.3-72-72S32.3 0 72 0s72 32.3 72 72-32.3 72-72 72zM72 6.1C35.7 6.1 6.1 35.7 6.1 72s29.6 65.9 65.9 65.9 66-29.6 66-65.9S108.4 6.1 72 6.1z"/>
+	<path d="M72 14.7a56.5 56.5 0 0 0-49.7 83.4c1.5-1.1 3.1-2.2 4.9-3.3 31-18.5 58.4-33.7 76.6-62 0 0-1.3 32-19.7 46.9-4.1 3.3-7.6 5.9-10.9 8 9.3-4.9 17.4-10.5 23.7-18 0 0-.5 21.5-16.3 31-5.9 3.5-10.8 5.5-15.8 7 9-2 14.9-4.5 19.6-7.7-4 13.3-12.7 20.3-26.2 22.3-4.9.5-9.1-.5-13.5-1.5 8.1 4.5 17.4 7 27.3 7 31.2 0 56.5-25.3 56.5-56.5S103.3 14.7 72 14.7z"/>
 </svg>


### PR DESCRIPTION
Since the profiler redesign, there is a visual "bug" with the Mercure profiler icon. 

It's hard to say in a quick look if mercure is enabled or not, because the icon does not change its color 
(every other is now drak when active and light when inactive / empty)

Moreover, the icon color is now a bit "eye-catching" compared to the other. 

I suggest with this PR to use the same standards as the other panels.

## Before

| Disabled | Enabled | Current |
| - | - | - | 
| ![O-disabled](https://github.com/symfony/mercure-bundle/assets/1359581/955814af-13f9-462c-90b8-4f46dd20cb6e) |  ![O-enabled](https://github.com/symfony/mercure-bundle/assets/1359581/0f12b591-5717-457a-bc04-40ac317fc1b4) | ![O-active](https://github.com/symfony/mercure-bundle/assets/1359581/f21bd7c1-0323-44ed-b153-a0bc44abd7b1) | 

## After

| Disabled | Enabled | Current |
| - | - | - | 
| ![L-disabled](https://github.com/symfony/mercure-bundle/assets/1359581/7f8f12d1-f37d-48e7-98e0-8517ccd71d06) | ![L-enabled](https://github.com/symfony/mercure-bundle/assets/1359581/880b7c8f-ff08-4c81-bf34-5c4bce5be080) | ![L-active](https://github.com/symfony/mercure-bundle/assets/1359581/690a2396-ef7c-4bf7-8d53-fcd0a4d127be) | 

| Disabled | Enabled | Current |
| - | - | - | 
| ![D-disabled](https://github.com/symfony/mercure-bundle/assets/1359581/72753e06-9edf-4119-a729-24b8602c8904) |  ![D-enabled](https://github.com/symfony/mercure-bundle/assets/1359581/1f49e3e6-917a-46e4-87b9-6f0581f829ed) | ![D-active](https://github.com/symfony/mercure-bundle/assets/1359581/1c64735f-2f0d-4a01-a886-e85ab5c496f6) |







