### PR TITLE
add twig parameter for TurboStreamListenRenderer

### DIFF
--- a/src/DependencyInjection/MercureExtension.php
+++ b/src/DependencyInjection/MercureExtension.php
@@ -213,6 +213,7 @@ final class MercureExtension extends Extension
                     // uses an alias dynamically registered in a compiler pass
                     ->addArgument(new Reference('turbo.mercure.stimulus_helper'))
                     ->addArgument(new Reference('turbo.id_accessor'))
+                    ->addArgument(new Reference('twig'))
                     ->addTag('turbo.renderer.stream_listen', ['transport' => $name]);
 
                 if ($defaultHubName === $name && 'default' !== $name) {


### PR DESCRIPTION
workaround for #94 

until #94 is cleanly solved, this would allow to install mercure-bundle and symfony/ux-turbo in their latest versions.

i see that ux-turbo does provide a RegisterMercureHubsPass so maybe the proper solution here would be to just remove this service definition (and declare a conflict with symfony/ux-turbo versions that do not have that compiler pass)