### PR TITLE
fix #91 : split publisher & subscriber jwt logic

### DIFF
--- a/src/DependencyInjection/MercureExtension.php
+++ b/src/DependencyInjection/MercureExtension.php
@@ -328,6 +328,7 @@ final class MercureExtension extends Extension
                 ->setArguments([new Reference(HubRegistry::class), new Reference(Authorization::class), new Reference('request_stack')]);
 
             /* @phpstan-ignore function.impossibleType */
+            /* @phpstan-ignore function.alreadyNarrowedType */
             if (is_a(TwigMercureExtension::class, AbstractExtension::class, true)) {
                 $definition->addTag('twig.extension');
             } else {

--- a/tests/MercureBundleTest.php
+++ b/tests/MercureBundleTest.php
@@ -48,7 +48,7 @@ class MercureBundleTest extends TestCase
         (new MercureBundle())->build($container);
 
         // prevent unused services removal/inlining and missing optional services errors
-        $container->getCompilerPassConfig()->setRemovingPasses(array_filter($container->getCompilerPassConfig()->getRemovingPasses(), function (CompilerPassInterface $pass) {
+        $container->getCompilerPassConfig()->setRemovingPasses(array_filter($container->getCompilerPassConfig()->getRemovingPasses(), static function (CompilerPassInterface $pass) {
             return !(
                 $pass instanceof RemoveUnusedDefinitionsPass
                 || $pass instanceof CheckExceptionOnInvalidReferenceBehaviorPass
@@ -73,7 +73,7 @@ class MercureBundleTest extends TestCase
         (new MercureBundle())->build($container);
 
         // prevent unused services removal/inlining and missing optional services errors
-        $container->getCompilerPassConfig()->setRemovingPasses(array_filter($container->getCompilerPassConfig()->getRemovingPasses(), function (CompilerPassInterface $pass) {
+        $container->getCompilerPassConfig()->setRemovingPasses(array_filter($container->getCompilerPassConfig()->getRemovingPasses(), static function (CompilerPassInterface $pass) {
             return !(
                 $pass instanceof RemoveUnusedDefinitionsPass
                 || $pass instanceof CheckExceptionOnInvalidReferenceBehaviorPass


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                            
                                                        
  - Split the single `jwt` config node into separate `publisher` and `subscriber` sections, aligning the bundle config with the upstream `Hub` class which already models these as two distinct concerns (`TokenProviderInterface` for  
  publishing, `TokenFactoryInterface` for subscriber cookies)                                                                                                                                                                           
  - The legacy `jwt` / `jwt_provider` config is automatically normalized into the new format via `beforeNormalization`, so **no existing config breaks**                                                                                
  - When publisher and subscriber share identical secret/algorithm/passphrase, a single `LcobucciFactory` is registered (backward-compatible service IDs preserved)                                                                     

  ## New config API

  ```yaml
  mercure:
    hubs:
      default:
        url: https://demo.mercure.rocks/hub

        publisher:                            # → TokenProviderInterface
          # Option A: static token
          value: "eyJhbG..."
          # Option B: custom service
          provider: app.my_token_provider
          # Option C: factory (wraps as FactoryTokenProvider)
          factory: app.my_token_factory
          # Option D: auto-generated LcobucciFactory
          secret: "publisher-key"
          algorithm: hmac.sha256              # default
          passphrase: ""                      # default
          topics: ['*']                       # → mercure.publish JWT claim

        subscriber:                           # → TokenFactoryInterface
          # Option A: custom service
          factory: app.my_token_factory
          # Option B: auto-generated LcobucciFactory
          secret: "subscriber-key"
          algorithm: hmac.sha256              # default
          passphrase: ""                      # default
          topics: ['https://example.com/{id}'] # → mercure.subscribe JWT claim

  Minimal example (separate keys)

  mercure:
    hubs:
      default:
        url: https://hub.example.com/.well-known/mercure
        publisher:
          secret: "%env(MERCURE_PUBLISHER_KEY)%"
          topics: ['*']
        subscriber:
          secret: "%env(MERCURE_SUBSCRIBER_KEY)%"

  Minimal example (static JWT, no subscriber)

  mercure:
    hubs:
      default:
        url: https://hub.example.com/.well-known/mercure
        publisher:
          value: "%env(MERCURE_JWT)%"

  Legacy config (still works, deprecated in 0.5)

  mercure:
    hubs:
      default:
        url: https://hub.example.com/.well-known/mercure
        jwt:
          secret: "!ChangeMe!"
          publish: ['*']
          subscribe: ['https://example.com/book/{id}']

  This is automatically normalized to:

  publisher:
    secret: "!ChangeMe!"
    algorithm: hmac.sha256
    topics: ['*']
  subscriber:
    secret: "!ChangeMe!"
    algorithm: hmac.sha256
    topics: ['https://example.com/book/{id}']