### PR TITLE
Make `RemoteHubInterface` autowirable

### DIFF
--- a/src/DependencyInjection/MercureExtension.php
+++ b/src/DependencyInjection/MercureExtension.php
@@ -42,6 +42,7 @@ use Symfony\Component\Mercure\Jwt\TokenProviderInterface;
 use Symfony\Component\Mercure\Messenger\UpdateHandler;
 use Symfony\Component\Mercure\Publisher;
 use Symfony\Component\Mercure\PublisherInterface;
+use Symfony\Component\Mercure\RemoteHubInterface;
 use Symfony\Component\Mercure\Twig\MercureExtension as TwigMercureExtension;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\UX\Turbo\Bridge\Mercure\Broadcaster;
@@ -172,6 +173,8 @@ final class MercureExtension extends Extension
             if (!$builtinHub) {
                 $container->registerAliasForArgument($hubId, HubInterface::class, "{$name}Hub");
                 $container->registerAliasForArgument($hubId, HubInterface::class, $name);
+                $container->registerAliasForArgument($hubId, RemoteHubInterface::class, "{$name}Hub");
+                $container->registerAliasForArgument($hubId, RemoteHubInterface::class, $name);
 
                 $publisherDefinition = $container->register($publisherId, Publisher::class)
                     ->addArgument($hub['url'])
@@ -257,6 +260,7 @@ final class MercureExtension extends Extension
         }
 
         $container->setAlias(HubInterface::class, $defaultHubId);
+        $container->setAlias(RemoteHubInterface::class, $defaultHubId);
 
         if (null !== $defaultPublisher) {
             $this->deprecate(

--- a/tests/DependencyInjection/MercureExtensionTest.php
+++ b/tests/DependencyInjection/MercureExtensionTest.php
@@ -50,10 +50,12 @@ class MercureExtensionTest extends TestCase
         $this->assertSame($config['mercure']['hubs']['default']['jwt'], $container->getDefinition('mercure.hub.default.jwt.provider')->getArgument(0));
 
         $this->assertArrayHasKey('Symfony\Component\Mercure\HubInterface $default', $container->getAliases());
+        $this->assertArrayHasKey('Symfony\Component\Mercure\RemoteHubInterface $default', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\PublisherInterface $default', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $default', $container->getAliases());
 
         $this->assertArrayHasKey('Symfony\Component\Mercure\HubInterface $defaultHub', $container->getAliases());
+        $this->assertArrayHasKey('Symfony\Component\Mercure\RemoteHubInterface $defaultHub', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\PublisherInterface $defaultPublisher', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $defaultProvider', $container->getAliases());
 


### PR DESCRIPTION
Next to https://github.com/symfony/mercure/pull/129, avoids duck-typing for `getUrl()`