### PR TITLE
Allow to use a Hub argument aliases for a builtin Hub

### DIFF
--- a/src/DependencyInjection/MercureExtension.php
+++ b/src/DependencyInjection/MercureExtension.php
@@ -169,10 +169,10 @@ final class MercureExtension extends Extension
                     ->addTag('mercure.hub');
             }
 
-            if (!$builtinHub) {
-                $container->registerAliasForArgument($hubId, HubInterface::class, "{$name}Hub");
-                $container->registerAliasForArgument($hubId, HubInterface::class, $name);
+            $container->registerAliasForArgument($hubId, HubInterface::class, "{$name}Hub");
+            $container->registerAliasForArgument($hubId, HubInterface::class, $name);
 
+            if (!$builtinHub) {
                 $publisherDefinition = $container->register($publisherId, Publisher::class)
                     ->addArgument($hub['url'])
                     ->addArgument(new Reference($tokenProvider))

--- a/tests/DependencyInjection/MercureExtensionTest.php
+++ b/tests/DependencyInjection/MercureExtensionTest.php
@@ -92,6 +92,9 @@ class MercureExtensionTest extends TestCase
                             'subscribe' => 'https://example.com/book/1.jsonld',
                         ],
                     ],
+                    'builtin' => [
+                        'public_url' => 'https://example.com/.well-known/mercure',
+                    ],
                 ],
             ],
         ];
@@ -146,6 +149,25 @@ class MercureExtensionTest extends TestCase
 
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $managed2TokenProvider', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $managed2TokenFactory', $container->getAliases());
+
+        $this->assertTrue($container->hasDefinition('mercure.hub.builtin')); // Hub instance
+        $this->assertFalse($container->hasDefinition('mercure.hub.builtin.publisher')); // Publisher
+        $this->assertFalse($container->hasDefinition('mercure.hub.builtin.jwt.provider'));
+        $this->assertFalse($container->hasDefinition('mercure.hub.builtin.jwt.factory'));
+        $this->assertSame($config['mercure']['hubs']['builtin']['public_url'], $container->getDefinition('mercure.hub.builtin')->getArgument(0));
+
+        $this->assertArrayHasKey('Symfony\Component\Mercure\HubInterface $builtin', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\PublisherInterface $builtin', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $builtin', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $builtin', $container->getAliases());
+
+        $this->assertArrayHasKey('Symfony\Component\Mercure\HubInterface $builtinHub', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\PublisherInterface $builtinPublisher', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $builtinProvider', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $builtinFactory', $container->getAliases());
+
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $builtinTokenProvider', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $builtinTokenFactory', $container->getAliases());
 
         $this->assertTrue($container->hasDefinition('mercure.hub.demo')); // Hub instance
         $this->assertTrue($container->hasDefinition('mercure.hub.demo.publisher')); // Publisher


### PR DESCRIPTION
After #106, autowire of the `HubInterface $name` and `HubInterface $nameHub` arguments became unavailable when using the builtin Hub. With this PR, I propose reverting to the previous behavior for such arguments.