### PR TITLE
Make hub resolving is lazy

### DIFF
--- a/src/DependencyInjection/MercureExtension.php
+++ b/src/DependencyInjection/MercureExtension.php
@@ -14,9 +14,12 @@ declare(strict_types=1);
 namespace Symfony\Bundle\MercureBundle\DependencyInjection;
 
 use Symfony\Bundle\MercureBundle\DataCollector\MercureDataCollector;
+use Symfony\Bundle\MercureBundle\HubChooser;
+use Symfony\Bundle\MercureBundle\PublisherChooser;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Compiler\AliasDeprecatedPublicServicesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -74,6 +77,7 @@ final class MercureExtension extends Extension
         $enableProfiler = ($config['enable_profiler'] ?? $container->getParameter('kernel.debug')) && class_exists(Stopwatch::class);
         foreach ($config['hubs'] as $name => $hub) {
             $builtinHub = !isset($hub['url']);
+            $lazyHubResolve = isset($hub['url']) && str_contains($hub['url'], 'env_');
 
             $tokenFactory = null;
             $tokenProvider = null;
@@ -154,7 +158,33 @@ final class MercureExtension extends Extension
                 $defaultPublisher = $publisherId;
             }
 
-            if ($builtinHub) {
+            if ($lazyHubResolve) {
+                $hubChooserId = \sprintf('mercure.hub.%s.chooser', $name);
+                $externalHubId = \sprintf('mercure.hub.%s.external_hub', $name);
+                $builtinHubId = \sprintf('mercure.hub.%s.builtin_hub', $name);
+
+                $container->register($hubId, HubInterface::class)
+                    ->setFactory([new Reference($hubChooserId), 'chooseHub'])
+                    ->addArgument($hub['url'])
+                    ->addTag('mercure.hub');
+
+                $container->register($hubChooserId, HubChooser::class)
+                    ->addArgument(new ServiceLocatorArgument([
+                        'external' => new Reference($externalHubId),
+                        'builtin' => new Reference($builtinHubId),
+                    ]));
+
+                $container->register($externalHubId, Hub::class)
+                    ->addArgument($hub['url'])
+                    ->addArgument(new Reference($tokenProvider))
+                    ->addArgument($tokenFactory ? new Reference($tokenFactory) : null)
+                    ->addArgument($hub['public_url'])
+                    ->addArgument(new Reference('http_client', ContainerInterface::IGNORE_ON_INVALID_REFERENCE));
+
+                $container->register($builtinHubId, FrankenPhpHub::class)
+                    ->addArgument($hub['public_url'])
+                    ->addArgument($tokenFactory ? new Reference($tokenFactory) : null);
+            } elseif ($builtinHub) {
                 $container->register($hubId, FrankenPhpHub::class)
                     ->addArgument($hub['public_url'])
                     ->addArgument($tokenFactory ? new Reference($tokenFactory) : null)
@@ -169,7 +199,44 @@ final class MercureExtension extends Extension
                     ->addTag('mercure.hub');
             }
 
-            if (!$builtinHub) {
+            if ($lazyHubResolve) {
+                $container->registerAliasForArgument($hubId, HubInterface::class, "{$name}Hub");
+                $container->registerAliasForArgument($hubId, HubInterface::class, $name);
+
+                $publisherChooserId = \sprintf('mercure.hub.%s.publisher_chooser', $name);
+                $externalPublisherId = \sprintf('mercure.hub.%s.external_publisher', $name);
+
+                $container->register($publisherId, PublisherInterface::class)
+                    ->setFactory([new Reference($publisherChooserId), 'choosePublisher'])
+                    ->addArgument($hub['url'])
+                    ->addTag('mercure.publisher');
+
+                $container->register($publisherChooserId, PublisherChooser::class)
+                    ->addArgument(new ServiceLocatorArgument([
+                        'external' => new Reference($externalPublisherId),
+                    ]));
+
+                $publisherDefinition = $container->register($externalPublisherId, Publisher::class)
+                    ->addArgument($hub['url'])
+                    ->addArgument(new Reference($tokenProvider))
+                    ->addArgument(new Reference('http_client', ContainerInterface::IGNORE_ON_INVALID_REFERENCE))
+                    ->setLazy(true);
+
+                $this->deprecate(
+                    $publisherDefinition,
+                    'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future, use "'.$hubId.'" instead.'
+                );
+
+                $this->deprecate(
+                    $container->registerAliasForArgument($publisherId, PublisherInterface::class, "{$name}Publisher"),
+                    'The "%alias_id%" service is deprecated. You should stop using it, as it will be removed in the future, use "'.$hubId.'" instead.'
+                );
+
+                $this->deprecate(
+                    $container->registerAliasForArgument($publisherId, PublisherInterface::class, $name),
+                    'The "%alias_id%" service is deprecated. You should stop using it, as it will be removed in the future, use "'.$hubId.'" instead.'
+                );
+            } elseif (!$builtinHub) {
                 $container->registerAliasForArgument($hubId, HubInterface::class, "{$name}Hub");
                 $container->registerAliasForArgument($hubId, HubInterface::class, $name);
 
@@ -204,7 +271,7 @@ final class MercureExtension extends Extension
                 ->addTag('messenger.message_handler', $attributes);
 
             if ($enableProfiler) {
-                if (!$builtinHub) {
+                if (!$builtinHub || $lazyHubResolve) {
                     $traceablePublisher = $container->register("$publisherId.traceable", TraceablePublisher::class)
                         ->setDecoratedService($publisherId)
                         ->addArgument(new Reference("$publisherId.traceable.inner"))

--- a/src/HubChooser.php
+++ b/src/HubChooser.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Bundle\MercureBundle;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Mercure\HubInterface;
+
+/**
+ * @internal
+ *
+ * @author Stanislau Kviatkouski <7zete7@gmail.com>
+ */
+final class HubChooser
+{
+    public function __construct(
+        private ContainerInterface $hubs,
+    ) {
+    }
+
+    public function chooseHub(?string $hubUrl): HubInterface
+    {
+        return null === $hubUrl ? $this->hubs->get('builtin') : $this->hubs->get('external');
+    }
+}

--- a/src/PublisherChooser.php
+++ b/src/PublisherChooser.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Mercure Component project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Bundle\MercureBundle;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\PublisherInterface;
+
+/**
+ * @internal
+ *
+ * @author Stanislau Kviatkouski <7zete7@gmail.com>
+ */
+final class PublisherChooser
+{
+    public function __construct(
+        private ContainerInterface $publishers,
+    ) {
+    }
+
+    public function choosePublisher(?string $hubUrl): PublisherInterface
+    {
+        if (null !== $hubUrl) {
+            return $this->publishers->get('external');
+        }
+
+        throw new \RuntimeException(\sprintf('Unable to use "%s" with builtin Hub. Use "%s" instead.', PublisherInterface::class, HubInterface::class));
+    }
+}

--- a/tests/DependencyInjection/MercureExtensionTest.php
+++ b/tests/DependencyInjection/MercureExtensionTest.php
@@ -16,6 +16,7 @@ namespace Symfony\Bundle\MercureBundle\Tests\DependencyInjection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MercureBundle\DependencyInjection\MercureExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Mercure\FrankenPhpHub;
 use Symfony\Component\Mercure\Hub;
@@ -235,6 +236,67 @@ class MercureExtensionTest extends TestCase
 
         $this->assertTrue($container->hasDefinition('mercure.hub.default'));
         $this->assertSame(FrankenPhpHub::class, $container->getDefinition('mercure.hub.default')->getClass());
+    }
+
+    public function testExtensionLazyHubResolving()
+    {
+        if (!class_exists(FrankenPhpHub::class)) {
+            $this->markTestSkipped('FrankenPhpHub is not available (old version of symfony/mercure).');
+        }
+
+        $parameterBag = new EnvPlaceholderParameterBag(['kernel.debug' => false]);
+        $container = new ContainerBuilder($parameterBag);
+
+        $config = [
+            'mercure' => [
+                'hubs' => [
+                    [
+                        'name' => 'builtin',
+                        'url' => $parameterBag->get('env(default::BUILTIN_HUB_URL)'),
+                        'public_url' => $parameterBag->get('env(default::BUILTIN_HUB_PUBLIC_URL)'),
+                        'jwt' => [
+                            'secret' => $parameterBag->get('env(default::BUILTIN_HUB_JWT_SECRET)'),
+                            'publish' => '*',
+                        ],
+                    ],
+                    [
+                        'name' => 'external',
+                        'url' => $parameterBag->get('env(default::EXTERNAL_HUB_URL)'),
+                        'public_url' => $parameterBag->get('env(default::EXTERNAL_HUB_PUBLIC_URL)'),
+                        'jwt' => [
+                            'secret' => $parameterBag->get('env(default::EXTERNAL_HUB_JWT_SECRET)'),
+                            'publish' => '*',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $_SERVER['BUILTIN_HUB_URL'] = null;
+        $_SERVER['BUILTIN_HUB_PUBLIC_URL'] = 'https://demo.mercure.rocks/hub';
+        $_SERVER['BUILTIN_HUB_JWT_SECRET'] = null;
+
+        $_SERVER['EXTERNAL_HUB_URL'] = 'https://demo.mercure.rocks/hub';
+        $_SERVER['EXTERNAL_HUB_PUBLIC_URL'] = 'https://demo.mercure.rocks/hub';
+        $_SERVER['EXTERNAL_HUB_JWT_SECRET'] = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.HB0k08BaV8KlLZ3EafCRlTDGbkd9qdznCzJQ_l8ELTU';
+
+        (new MercureExtension())->load($config, $container);
+
+        $this->assertTrue($container->hasDefinition('mercure.hub.builtin'));
+        $this->assertTrue($container->hasDefinition('mercure.hub.builtin.builtin_hub'));
+        $this->assertTrue($container->hasDefinition('mercure.hub.builtin.external_hub'));
+
+        $this->assertTrue($container->hasDefinition('mercure.hub.external'));
+        $this->assertTrue($container->hasDefinition('mercure.hub.external.builtin_hub'));
+        $this->assertTrue($container->hasDefinition('mercure.hub.external.external_hub'));
+
+        $container->getDefinition('mercure.hub.builtin')->setPublic(true);
+        $container->getDefinition('mercure.hub.external')->setPublic(true);
+
+        $container->compile(true);
+
+        $this->assertInstanceOf(FrankenPhpHub::class, $container->get('mercure.hub.builtin'));
+        $this->assertInstanceOf(Hub::class, $container->get('mercure.hub.external'));
     }
 }
 


### PR DESCRIPTION
The current implementation of builtin Hub detection doesn't support the use of `env(...)` (see https://github.com/dunglas/symfony-docker/pull/869#issuecomment-4124841316). With this PR, I propose adding lazy detection of the appropriate implementation based on the values ​​of envs at runtime if `env(...)` is used.