### PR TITLE
[Mercure] Add support for Mercure v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.5
+---
+
+* Add support for the Mercure v1 protocol
+
 0.4.2
 -----
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -68,14 +68,30 @@ final class Configuration implements ConfigurationInterface
                     ->scalarNode('provider')->info('The ID of a service to call to provide the JSON Web Token.')->end()
                     ->scalarNode('factory')->info('The ID of a service to call to create the JSON Web Token.')->end()
                     ->arrayNode('publish')
-                        ->beforeNormalization()->castToArray()->end()
-                        ->scalarPrototype()->end()
-                        ->info('A list of topics to allow publishing to when using the given factory to generate the JWT.')
+                        ->beforeNormalization()
+                            ->always(static function ($v) {
+                                if (is_string($v) || (is_array($v) && isset($v['match']))) {
+                                    return [$v];
+                                }
+
+                                return (array) $v;
+                            })
+                        ->end()
+                        ->variablePrototype()->end()
+                        ->info('Matchers used to filter authorized topics for publishing.')
                     ->end()
                     ->arrayNode('subscribe')
-                        ->beforeNormalization()->castToArray()->end()
-                        ->scalarPrototype()->end()
-                        ->info('A list of topics to allow subscribing to when using the given factory to generate the JWT.')
+                        ->beforeNormalization()
+                            ->always(static function ($v) {
+                                if (is_string($v) || (is_array($v) && isset($v['match']))) {
+                                    return [$v];
+                                }
+
+                                return (array) $v;
+                            })
+                        ->end()
+                        ->variablePrototype()->end()
+                        ->info('Matchers used to filter authorized topics for subscription.')
                     ->end()
                     ->scalarNode('secret')->info('The JWT Secret to use.')->example('!ChangeMe!')->end()
                     ->scalarNode('passphrase')->info('The JWT secret passphrase.')->defaultValue('')->end()
@@ -87,6 +103,11 @@ final class Configuration implements ConfigurationInterface
             ->setDeprecated('symfony/mercure-bundle', '0.3', 'The child node "%node%" at path "%path%" is deprecated, use "jwt.provider" instead.')
         ->end()
         ->scalarNode('bus')->info('Name of the Messenger bus where the handler for this hub must be registered. Default to the default bus if Messenger is enabled.')->end()
+        ->enumNode('version')
+            ->values(['v0', 'v1'])
+            ->defaultValue('v1')
+            ->info('The Mercure protocol version to use (v0 for legacy, v1 for current).')
+        ->end()
                             ->end()
                             ->validate()
         ->ifTrue(function ($v) { return isset($v['jwt'], $v['jwt_provider']); })

--- a/src/DependencyInjection/MercureExtension.php
+++ b/src/DependencyInjection/MercureExtension.php
@@ -39,6 +39,7 @@ use Symfony\Component\Mercure\Jwt\StaticJwtProvider;
 use Symfony\Component\Mercure\Jwt\StaticTokenProvider;
 use Symfony\Component\Mercure\Jwt\TokenFactoryInterface;
 use Symfony\Component\Mercure\Jwt\TokenProviderInterface;
+use Symfony\Component\Mercure\MercureVersion;
 use Symfony\Component\Mercure\Messenger\UpdateHandler;
 use Symfony\Component\Mercure\Publisher;
 use Symfony\Component\Mercure\PublisherInterface;
@@ -74,6 +75,7 @@ final class MercureExtension extends Extension
         $enableProfiler = ($config['enable_profiler'] ?? $container->getParameter('kernel.debug')) && class_exists(Stopwatch::class);
         foreach ($config['hubs'] as $name => $hub) {
             $builtinHub = !isset($hub['url']);
+            $version = 'v0' === ($hub['version'] ?? 'v1') ? MercureVersion::V0 : MercureVersion::V1;
 
             $tokenFactory = null;
             $tokenProvider = null;
@@ -107,6 +109,7 @@ final class MercureExtension extends Extension
                             ->addArgument($hub['jwt']['algorithm'])
                             ->addArgument(null)
                             ->addArgument($hub['jwt']['passphrase'])
+                            ->addArgument($version)
                             ->addTag('mercure.jwt.factory');
                     }
 
@@ -158,6 +161,7 @@ final class MercureExtension extends Extension
                 $container->register($hubId, FrankenPhpHub::class)
                     ->addArgument($hub['public_url'])
                     ->addArgument($tokenFactory ? new Reference($tokenFactory) : null)
+                    ->addArgument($version)
                     ->addTag('mercure.hub');
             } else {
                 $container->register($hubId, Hub::class)
@@ -166,6 +170,7 @@ final class MercureExtension extends Extension
                     ->addArgument($tokenFactory ? new Reference($tokenFactory) : null)
                     ->addArgument($hub['public_url'])
                     ->addArgument(new Reference('http_client', ContainerInterface::IGNORE_ON_INVALID_REFERENCE))
+                    ->addArgument($version)
                     ->addTag('mercure.hub');
             }
 


### PR DESCRIPTION
# Intro
Please note that this can't be run or used standalone just yet. It was built specifically to handle Mercure v1 compatibility and relies on PR on the Mercure component for Symfony that is still pending : https://github.com/symfony/mercure/pull/137

# What I implemented
I implemented matchers and the choice for Mercure version inside the bundle configuration and passed the selected version to the JWT factory and the hubs.