### PR TITLE
Bound the symfony/mercure requirement back to the supported versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/config": "^6.4|^7.3|^8.0",
         "symfony/dependency-injection": "^6.4|^7.3|^8.0",
         "symfony/http-kernel": "^6.4|^7.3|^8.0",
-        "symfony/mercure": "*",
+        "symfony/mercure": "^0.6.1|^0.7",
         "symfony/web-link": "^6.4|^7.3|^8.0"
     },
     "autoload": {


### PR DESCRIPTION
The constraint was loosened from `^0.6.1` to `*` in #106 to allow resolving an unreleased `symfony/mercure` while FrankenPHP hub support was being added, and was never restored.

Since then, `symfony/mercure` 0.8 added `HubInterface::getProtocolVersion()` and `HubInterface::getCookieName()`, which the bundle does not support yet, and `*` lets that version be installed. Downstream projects then fail to load any class implementing `HubInterface` — that is what currently breaks symfony/symfony's CI, where this bundle is the only thing pulling in `symfony/mercure`:

```
PHP Fatal error:  Class Symfony\Component\Notifier\Bridge\Mercure\Tests\Fixtures\DummyHub contains
2 abstract methods and must therefore be declared abstract or implement the remaining methods
(Symfony\Component\Mercure\HubInterface::getProtocolVersion, Symfony\Component\Mercure\HubInterface::getCookieName)
```

`FrankenPhpHub` is behind a `class_exists()` check, so 0.6.1 stays usable and the constraint can be widened again once the bundle supports 0.8.