### PR TITLE
Remove legacy Publisher BC services that trigger boot-time deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+Unreleased
+----------
+
+* **BC break:** Stop registering the legacy `Publisher` / `PublisherInterface` / `TraceablePublisher` services and aliases, and the `StaticJwtProvider` service (`mercure.hub.*.jwt_provider`). Apps must use `Hub` / `HubInterface` / `TraceableHub` and `StaticTokenProvider` (`mercure.hub.*.jwt.provider`) instead. This removes the `symfony/mercure` 0.5 deprecations that were triggered on every container boot even when the Hub API was used exclusively (#121)
+
 0.5.0
 -----
 

--- a/src/DataCollector/MercureDataCollector.php
+++ b/src/DataCollector/MercureDataCollector.php
@@ -17,17 +17,16 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\Mercure\Debug\TraceableHub;
-use Symfony\Component\Mercure\Debug\TraceablePublisher;
 
 final class MercureDataCollector extends DataCollector
 {
     /**
-     * @var iterable<TraceablePublisher|TraceableHub>
+     * @var iterable<TraceableHub>
      */
     private $hubs;
 
     /**
-     * @param iterable<TraceablePublisher|TraceableHub> $hubs
+     * @param iterable<TraceableHub> $hubs
      */
     public function __construct(iterable $hubs)
     {

--- a/src/DependencyInjection/MercureExtension.php
+++ b/src/DependencyInjection/MercureExtension.php
@@ -17,9 +17,7 @@ use Jose\Component\Core\JWK;
 use Symfony\Bundle\MercureBundle\DataCollector\MercureDataCollector;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
-use Symfony\Component\DependencyInjection\Compiler\AliasDeprecatedPublicServicesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
@@ -27,7 +25,6 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Mercure\Authorization;
 use Symfony\Component\Mercure\Debug\TraceableHub;
-use Symfony\Component\Mercure\Debug\TraceablePublisher;
 use Symfony\Component\Mercure\Discovery;
 use Symfony\Component\Mercure\EventSubscriber\SetCookieSubscriber;
 use Symfony\Component\Mercure\FrankenPhpHub;
@@ -39,15 +36,12 @@ use Symfony\Component\Mercure\Jwt\DefaultClaimsTokenFactory;
 use Symfony\Component\Mercure\Jwt\FactoryTokenProvider;
 use Symfony\Component\Mercure\Jwt\Grant;
 use Symfony\Component\Mercure\Jwt\LcobucciFactory;
-use Symfony\Component\Mercure\Jwt\StaticJwtProvider;
 use Symfony\Component\Mercure\Jwt\StaticTokenProvider;
 use Symfony\Component\Mercure\Jwt\TokenFactoryInterface;
 use Symfony\Component\Mercure\Jwt\TokenProviderInterface;
 use Symfony\Component\Mercure\Jwt\WebTokenFactory;
 use Symfony\Component\Mercure\Messenger\UpdateHandler;
 use Symfony\Component\Mercure\ProtocolVersion;
-use Symfony\Component\Mercure\Publisher;
-use Symfony\Component\Mercure\PublisherInterface;
 use Symfony\Component\Mercure\Twig\MercureExtension as TwigMercureExtension;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\UX\Turbo\Bridge\Mercure\Broadcaster;
@@ -77,7 +71,6 @@ final class MercureExtension extends Extension
             return;
         }
 
-        $defaultPublisher = null;
         $defaultHubId = null;
         $traceableHubs = [];
         $hubs = [];
@@ -97,16 +90,6 @@ final class MercureExtension extends Extension
                     $container->register($tokenProvider, StaticTokenProvider::class)
                         ->addArgument($hub['jwt']['value'])
                         ->addTag('mercure.jwt.provider');
-
-                    // TODO: remove the following definition in 0.4
-                    $jwtProvider = \sprintf('mercure.hub.%s.jwt_provider', $name);
-                    $jwtProviderDefinition = $container->register($jwtProvider, StaticJwtProvider::class)
-                        ->addArgument($hub['jwt']['value']);
-
-                    $this->deprecate(
-                        $jwtProviderDefinition,
-                        'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future, use "'.$tokenProvider.'" instead.'
-                    );
                 } elseif (isset($hub['jwt']['provider'])) {
                     $tokenProvider = $hub['jwt']['provider'];
                 } else {
@@ -179,12 +162,10 @@ final class MercureExtension extends Extension
             }
 
             $hubId = \sprintf('mercure.hub.%s', $name);
-            $publisherId = \sprintf('mercure.hub.%s.publisher', $name);
             $hubs[$name] = new Reference($hubId);
-            if (!$defaultPublisher && ($config['default_hub'] ?? $name) === $name) {
+            if (null === $defaultHubId && ($config['default_hub'] ?? $name) === $name) {
                 $defaultHubName = $name;
                 $defaultHubId = $hubId;
-                $defaultPublisher = $publisherId;
             }
 
             if ($builtinHub) {
@@ -204,32 +185,9 @@ final class MercureExtension extends Extension
                     ->addArgument($cookieName)
                     ->addArgument($protocolVersion)
                     ->addTag('mercure.hub');
-            }
 
-            if (!$builtinHub) {
                 $container->registerAliasForArgument($hubId, HubInterface::class, "{$name}Hub");
                 $container->registerAliasForArgument($hubId, HubInterface::class, $name);
-
-                $publisherDefinition = $container->register($publisherId, Publisher::class)
-                    ->addArgument($hub['url'])
-                    ->addArgument(new Reference($tokenProvider))
-                    ->addArgument(new Reference('http_client', ContainerInterface::IGNORE_ON_INVALID_REFERENCE))
-                    ->addTag('mercure.publisher');
-
-                $this->deprecate(
-                    $publisherDefinition,
-                    'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future, use "'.$hubId.'" instead.'
-                );
-
-                $this->deprecate(
-                    $container->registerAliasForArgument($publisherId, PublisherInterface::class, "{$name}Publisher"),
-                    'The "%alias_id%" service is deprecated. You should stop using it, as it will be removed in the future, use "'.$hubId.'" instead.'
-                );
-
-                $this->deprecate(
-                    $container->registerAliasForArgument($publisherId, PublisherInterface::class, $name),
-                    'The "%alias_id%" service is deprecated. You should stop using it, as it will be removed in the future, use "'.$hubId.'" instead.'
-                );
             }
 
             $bus = $hub['bus'] ?? null;
@@ -241,20 +199,6 @@ final class MercureExtension extends Extension
                 ->addTag('messenger.message_handler', $attributes);
 
             if ($enableProfiler) {
-                if (!$builtinHub) {
-                    $traceablePublisher = $container->register("$publisherId.traceable", TraceablePublisher::class)
-                        ->setDecoratedService($publisherId)
-                        ->addArgument(new Reference("$publisherId.traceable.inner"))
-                        ->addArgument(new Reference('debug.stopwatch'));
-
-                    $this->deprecate(
-                        $traceablePublisher,
-                        'The "%service_id%" service is deprecated. Use "'.$hubId.'.traceable" instead.'
-                    );
-
-                    $traceableHubs[$name] = new Reference("$publisherId.traceable");
-                }
-
                 $container->register("$hubId.traceable", TraceableHub::class)
                     ->setDecoratedService($hubId)
                     ->addArgument(new Reference("$hubId.traceable.inner"))
@@ -294,18 +238,6 @@ final class MercureExtension extends Extension
         }
 
         $container->setAlias(HubInterface::class, $defaultHubId);
-
-        if (null !== $defaultPublisher) {
-            $this->deprecate(
-                $container->setAlias(Publisher::class, $defaultPublisher),
-                'The "%alias_id%" service alias is deprecated. Use "'.Hub::class.'" instead.'
-            );
-
-            $this->deprecate(
-                $container->setAlias(PublisherInterface::class, $defaultPublisher),
-                'The "%alias_id%" service alias is deprecated. Use "'.HubInterface::class.'" instead.'
-            );
-        }
 
         $container->register(HubRegistry::class)
             ->addArgument(new Reference($defaultHubId))
@@ -386,18 +318,5 @@ final class MercureExtension extends Extension
             ->addTag('mercure.jwt.factory');
 
         return $tokenFactory;
-    }
-
-    /**
-     * @param Definition|Alias $definition
-     */
-    private function deprecate($definition, string $message): void
-    {
-        if (class_exists(AliasDeprecatedPublicServicesPass::class)) {
-            $definition->setDeprecated('symfony/mercure-bundle', '0.2', $message);
-        } else {
-            /* @phpstan-ignore-next-line */
-            $definition->setDeprecated(true, $message);
-        }
     }
 }

--- a/tests/DependencyInjection/MercureExtensionTest.php
+++ b/tests/DependencyInjection/MercureExtensionTest.php
@@ -50,24 +50,26 @@ class MercureExtensionTest extends TestCase
         (new MercureExtension())->load($config, $container);
 
         $this->assertTrue($container->hasDefinition('mercure.hub.default')); // Hub instance
-        $this->assertTrue($container->hasDefinition('mercure.hub.default.publisher')); // Publisher
+        $this->assertFalse($container->hasDefinition('mercure.hub.default.publisher'));
+        $this->assertFalse($container->hasDefinition('mercure.hub.default.jwt_provider'));
         $this->assertTrue($container->hasDefinition('mercure.hub.default.jwt.provider'));
-        $this->assertArrayHasKey('mercure.publisher', $container->getDefinition('mercure.hub.default.publisher')->getTags());
         $this->assertSame($config['mercure']['hubs']['default']['url'], $container->getDefinition('mercure.hub.default')->getArgument(0));
         $this->assertSame($config['mercure']['hubs']['default']['jwt'], $container->getDefinition('mercure.hub.default.jwt.provider')->getArgument(0));
         $this->assertSame(ProtocolVersion::Legacy, $container->getDefinition('mercure.hub.default')->getArgument(6));
         $this->assertNull($container->getDefinition('mercure.hub.default')->getArgument(5));
 
         $this->assertArrayHasKey('Symfony\Component\Mercure\HubInterface $default', $container->getAliases());
-        $this->assertArrayHasKey('Symfony\Component\Mercure\PublisherInterface $default', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\PublisherInterface $default', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $default', $container->getAliases());
 
         $this->assertArrayHasKey('Symfony\Component\Mercure\HubInterface $defaultHub', $container->getAliases());
-        $this->assertArrayHasKey('Symfony\Component\Mercure\PublisherInterface $defaultPublisher', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\PublisherInterface $defaultPublisher', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $defaultProvider', $container->getAliases());
 
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $defaultTokenProvider', $container->getAliases());
         $this->assertArrayNotHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $defaultTokenFactory', $container->getAliases());
+        $this->assertFalse($container->hasAlias(\Symfony\Component\Mercure\PublisherInterface::class));
+        $this->assertFalse($container->hasAlias(\Symfony\Component\Mercure\Publisher::class));
     }
 
     public function testExtension()
@@ -109,11 +111,10 @@ class MercureExtensionTest extends TestCase
         (new MercureExtension())->load($config, $container);
 
         $this->assertTrue($container->hasDefinition('mercure.hub.managed')); // Hub instance
-        $this->assertTrue($container->hasDefinition('mercure.hub.managed.publisher')); // Publisher
+        $this->assertFalse($container->hasDefinition('mercure.hub.managed.publisher'));
         $this->assertTrue($container->hasDefinition('mercure.hub.managed.jwt.provider'));
         $this->assertTrue($container->hasDefinition('mercure.hub.managed.jwt.factory'));
         $this->assertSame(LcobucciFactory::class, $container->getDefinition('mercure.hub.managed.jwt.factory')->getClass());
-        $this->assertArrayHasKey('mercure.publisher', $container->getDefinition('mercure.hub.managed.publisher')->getTags());
         $this->assertSame($config['mercure']['hubs']['managed']['url'], $container->getDefinition('mercure.hub.managed')->getArgument(0));
         $this->assertSame($config['mercure']['hubs']['managed']['jwt']['secret'], $container->getDefinition('mercure.hub.managed.jwt.factory')->getArgument(0));
         $this->assertSame(ProtocolVersion::Legacy, $container->getDefinition('mercure.hub.managed')->getArgument(6));
@@ -127,12 +128,12 @@ class MercureExtensionTest extends TestCase
         );
 
         $this->assertArrayHasKey('Symfony\Component\Mercure\HubInterface $managed', $container->getAliases());
-        $this->assertArrayHasKey('Symfony\Component\Mercure\PublisherInterface $managed', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\PublisherInterface $managed', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $managed', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $managed', $container->getAliases());
 
         $this->assertArrayHasKey('Symfony\Component\Mercure\HubInterface $managedHub', $container->getAliases());
-        $this->assertArrayHasKey('Symfony\Component\Mercure\PublisherInterface $managedPublisher', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\PublisherInterface $managedPublisher', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $managedProvider', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $managedFactory', $container->getAliases());
 
@@ -140,10 +141,9 @@ class MercureExtensionTest extends TestCase
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $managedTokenFactory', $container->getAliases());
 
         $this->assertTrue($container->hasDefinition('mercure.hub.managed2')); // Hub instance
-        $this->assertTrue($container->hasDefinition('mercure.hub.managed2.publisher')); // Publisher
+        $this->assertFalse($container->hasDefinition('mercure.hub.managed2.publisher'));
         $this->assertTrue($container->hasDefinition('mercure.hub.managed2.jwt.provider'));
         $this->assertTrue($container->hasDefinition('mercure.hub.managed2.jwt.factory'));
-        $this->assertArrayHasKey('mercure.publisher', $container->getDefinition('mercure.hub.managed2.publisher')->getTags());
         $this->assertSame($config['mercure']['hubs']['managed2']['url'], $container->getDefinition('mercure.hub.managed2')->getArgument(0));
         $this->assertSame($config['mercure']['hubs']['managed2']['jwt']['secret'], $container->getDefinition('mercure.hub.managed2.jwt.factory')->getArgument(0));
         $this->assertSame($config['mercure']['hubs']['managed2']['jwt']['algorithm'], $container->getDefinition('mercure.hub.managed2.jwt.factory')->getArgument(1));
@@ -159,12 +159,12 @@ class MercureExtensionTest extends TestCase
         $this->assertNull($container->getDefinition('mercure.hub.managed2')->getArgument(5));
 
         $this->assertArrayHasKey('Symfony\Component\Mercure\HubInterface $managed2', $container->getAliases());
-        $this->assertArrayHasKey('Symfony\Component\Mercure\PublisherInterface $managed2', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\PublisherInterface $managed2', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $managed2', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $managed2', $container->getAliases());
 
         $this->assertArrayHasKey('Symfony\Component\Mercure\HubInterface $managed2Hub', $container->getAliases());
-        $this->assertArrayHasKey('Symfony\Component\Mercure\PublisherInterface $managed2Publisher', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\PublisherInterface $managed2Publisher', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $managed2Provider', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $managed2Factory', $container->getAliases());
 
@@ -172,10 +172,9 @@ class MercureExtensionTest extends TestCase
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $managed2TokenFactory', $container->getAliases());
 
         $this->assertTrue($container->hasDefinition('mercure.hub.demo')); // Hub instance
-        $this->assertTrue($container->hasDefinition('mercure.hub.demo.publisher')); // Publisher
+        $this->assertFalse($container->hasDefinition('mercure.hub.demo.publisher'));
         $this->assertTrue($container->hasDefinition('mercure.hub.demo.jwt.provider'));
         $this->assertFalse($container->hasDefinition('mercure.hub.demo.jwt.factory'));
-        $this->assertArrayHasKey('mercure.publisher', $container->getDefinition('mercure.hub.demo.publisher')->getTags());
         $this->assertSame($config['mercure']['hubs']['demo']['url'], $container->getDefinition('mercure.hub.demo')->getArgument(0));
         $this->assertSame($config['mercure']['hubs']['demo']['public_url'], $container->getDefinition('mercure.hub.demo')->getArgument(3));
         $this->assertSame($config['mercure']['hubs']['demo']['jwt']['value'], $container->getDefinition('mercure.hub.demo.jwt.provider')->getArgument(0));
@@ -183,12 +182,12 @@ class MercureExtensionTest extends TestCase
         $this->assertNull($container->getDefinition('mercure.hub.demo')->getArgument(5));
 
         $this->assertArrayHasKey('Symfony\Component\Mercure\HubInterface $demo', $container->getAliases());
-        $this->assertArrayHasKey('Symfony\Component\Mercure\PublisherInterface $demo', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\PublisherInterface $demo', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $demo', $container->getAliases());
         $this->assertArrayNotHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $demo', $container->getAliases());
 
         $this->assertArrayHasKey('Symfony\Component\Mercure\HubInterface $demoHub', $container->getAliases());
-        $this->assertArrayHasKey('Symfony\Component\Mercure\PublisherInterface $demoPublisher', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\PublisherInterface $demoPublisher', $container->getAliases());
         $this->assertArrayHasKey('Symfony\Component\Mercure\Jwt\TokenProviderInterface $demoProvider', $container->getAliases());
         $this->assertArrayNotHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $demoFactory', $container->getAliases());
 
@@ -196,10 +195,7 @@ class MercureExtensionTest extends TestCase
         $this->assertArrayNotHasKey('Symfony\Component\Mercure\Jwt\TokenFactoryInterface $demoTokenFactory', $container->getAliases());
     }
 
-    /**
-     * @group legacy
-     */
-    public function testExtensionLegacy()
+    public function testExtensionLegacyNamedHubsConfig()
     {
         $config = [
             'mercure' => [
@@ -221,13 +217,13 @@ class MercureExtensionTest extends TestCase
         $container = new ContainerBuilder(new ParameterBag(['kernel.debug' => false]));
         (new MercureExtension())->load($config, $container);
 
-        $this->assertTrue($container->hasDefinition('mercure.hub.default.jwt_provider'));
-        $this->assertTrue($container->hasDefinition('mercure.hub.default.publisher'));
+        $this->assertFalse($container->hasDefinition('mercure.hub.default.jwt_provider'));
+        $this->assertFalse($container->hasDefinition('mercure.hub.default.publisher'));
+        $this->assertTrue($container->hasDefinition('mercure.hub.default.jwt.provider'));
         $this->assertSame('https://demo.mercure.rocks/hub', $container->getDefinition('mercure.hub.default')->getArgument(0));
-        $this->assertArrayHasKey('mercure.publisher', $container->getDefinition('mercure.hub.default.publisher')->getTags());
-        $this->assertSame('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.HB0k08BaV8KlLZ3EafCRlTDGbkd9qdznCzJQ_l8ELTU', $container->getDefinition('mercure.hub.default.jwt_provider')->getArgument(0));
-        $this->assertArrayHasKey('Symfony\Component\Mercure\PublisherInterface $defaultPublisher', $container->getAliases());
-        $this->assertArrayHasKey('Symfony\Component\Mercure\PublisherInterface $managedPublisher', $container->getAliases());
+        $this->assertSame('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.HB0k08BaV8KlLZ3EafCRlTDGbkd9qdznCzJQ_l8ELTU', $container->getDefinition('mercure.hub.default.jwt.provider')->getArgument(0));
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\PublisherInterface $defaultPublisher', $container->getAliases());
+        $this->assertArrayNotHasKey('Symfony\Component\Mercure\PublisherInterface $managedPublisher', $container->getAliases());
 
         $container->getDefinition(HubRegistry::class)->setPublic(true);
         $container->compile();
@@ -239,6 +235,28 @@ class MercureExtensionTest extends TestCase
         $this->assertSame($config['mercure']['hubs'][1]['url'], $registry->getHub('managed')->getUrl());
         $this->assertSame(ProtocolVersion::Legacy, $registry->getHub()->getProtocolVersion());
         $this->assertSame('mercureAuthorization', $registry->getHub()->getCookieName());
+    }
+
+    public function testProfilerRegistersTraceableHubOnly()
+    {
+        $config = [
+            'mercure' => [
+                'hubs' => [
+                    'default' => [
+                        'url' => 'https://demo.mercure.rocks/hub',
+                        'jwt' => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.HB0k08BaV8KlLZ3EafCRlTDGbkd9qdznCzJQ_l8ELTU',
+                    ],
+                ],
+            ],
+        ];
+
+        $container = new ContainerBuilder(new ParameterBag(['kernel.debug' => true]));
+        (new MercureExtension())->load($config, $container);
+
+        $this->assertTrue($container->hasDefinition('mercure.hub.default.traceable'));
+        $this->assertFalse($container->hasDefinition('mercure.hub.default.publisher'));
+        $this->assertFalse($container->hasDefinition('mercure.hub.default.publisher.traceable'));
+        $this->assertTrue($container->hasDefinition('data_collector.mercure'));
     }
 
     public function testExtensionBuiltin()


### PR DESCRIPTION
## Summary

Fixes #121.

`MercureExtension` still registered the pre-0.5 BC layer (`Publisher` / `PublisherInterface` / `TraceablePublisher`, and `StaticJwtProvider` as `mercure.hub.*.jwt_provider`) for every non-builtin hub.

Those classes call `trigger_deprecation()` at **file load time** (since `symfony/mercure` 0.5), so a standard Hub-only setup logged deprecations on every container compile / request even when the application never injected `PublisherInterface`.

This change removes that BC registration. The modern Hub path is unchanged:

- `Hub` / `HubInterface` / `TraceableHub`
- `StaticTokenProvider` / `FactoryTokenProvider` (`mercure.hub.*.jwt.provider`)
- config option `jwt_provider` (callable/service reference) is **kept**

There was already a TODO to drop this in 0.4; 0.5.0 shipped without removing it.

### BC break

Applications still type-hinting or fetching:

| Removed | Use instead |
|---------|-------------|
| `Publisher` / `PublisherInterface` | `Hub` / `HubInterface` |
| `mercure.hub.*.publisher` | `mercure.hub.*` |
| `TraceablePublisher` | `TraceableHub` |
| `mercure.hub.*.jwt_provider` (`StaticJwtProvider`) | `mercure.hub.*.jwt.provider` (`StaticTokenProvider`) |

## Test plan

- [x] `vendor/bin/simple-phpunit` — 27 tests, 138 assertions, OK
- [x] Assert legacy publisher / `jwt_provider` definitions and aliases are **not** registered
- [x] Assert profiler registers `TraceableHub` only (no `TraceablePublisher` decorator)
- [x] Named-hubs legacy config format still boots `HubRegistry` correctly


Made with [Cursor](https://cursor.com)